### PR TITLE
Fix relativePath handling when path is empty string

### DIFF
--- a/app/src/main/java/ch/bfh/adaid/service/A11yService.java
+++ b/app/src/main/java/ch/bfh/adaid/service/A11yService.java
@@ -320,7 +320,7 @@ public class A11yService extends AccessibilityService implements RuleObserver {
      * @return The relative node. Or null on error.
      */
     public AccessibilityNodeInfo processRelativePath(AccessibilityNodeInfo node, String relativePath) {
-        if (relativePath == null) {
+        if (relativePath == null || relativePath.isEmpty()) {
             return node;
         }
         for (String pathArg : relativePath.split("\\.")) {


### PR DESCRIPTION
When the relativePath is an empty string, i.e. for the Instagram Story and Reel rules, it is wrongly detected as invalid path.
This fixes that.