### PR TITLE
misc QOL improvements

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <queries>
         <intent>
             <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+
     <queries>
         <intent>
             <action android:name="android.intent.action.MAIN" />
         </intent>
     </queries>
+
     <application
-        android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,20 @@
                 android:name="android.accessibilityservice"
                 android:resource="@xml/a11y_service_config" />
         </service>
+
+        <service
+            android:name=".settings.A11yTileService"
+            android:exported="true"
+            android:icon="@drawable/ic_launcher_foreground"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+                android:value="true" />
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/ch/bfh/adaid/gui/main/MainActivity.java
+++ b/app/src/main/java/ch/bfh/adaid/gui/main/MainActivity.java
@@ -1,5 +1,6 @@
 package ch.bfh.adaid.gui.main;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
@@ -91,28 +92,38 @@ public class MainActivity extends AppCompatActivity implements RuleObserver, Rul
         }
     }
 
+    @SuppressLint("NotifyDataSetChanged")
+    private void notifyRulesChanged() {
+        runOnUiThread(() -> {
+            adapter.notifyDataSetChanged();
+            // Show / hide the special "empty view".
+            View emptyView = findViewById(R.id.empty_view);
+            emptyView.setVisibility(rules.isEmpty() ? View.VISIBLE : View.GONE);
+        });
+    }
+
     @Override
     public void onRuleLoad(List<Rule> rules) {
         this.rules.addAll(rules);
-        runOnUiThread(adapter::notifyDataSetChanged);
+        notifyRulesChanged();
     }
 
     @Override
     public void onRuleAdded(Rule rule) {
         rules.add(rule);
-        runOnUiThread(adapter::notifyDataSetChanged);
+        notifyRulesChanged();
     }
 
     @Override
     public void onRuleChanged(Rule rule) {
         rules.replaceAll(r -> r.id == rule.id ? rule : r);
-        runOnUiThread(adapter::notifyDataSetChanged);
+        notifyRulesChanged();
     }
 
     @Override
     public void onRuleRemoved(Rule rule) {
         rules.removeIf(r -> r.id == rule.id);
-        runOnUiThread(adapter::notifyDataSetChanged);
+        notifyRulesChanged();
     }
 
     @Override

--- a/app/src/main/java/ch/bfh/adaid/gui/rule/AppAdapter.java
+++ b/app/src/main/java/ch/bfh/adaid/gui/rule/AppAdapter.java
@@ -62,10 +62,13 @@ public class AppAdapter extends ArrayAdapter<String> {
      */
     public String[] sortPackages(List<ApplicationInfo> packages) {
         ArrayList<String> names = new ArrayList<>();
-        for (ApplicationInfo applicationInfo : packages){
-            if ((applicationInfo.flags & ApplicationInfo.FLAG_SYSTEM) == 0){
-                names.add(applicationInfo.packageName);
-            }
+        for (ApplicationInfo applicationInfo : packages) {
+            // TODO: On OnePlus 8 filtering for non-system apps hides the YouTube App.
+            //       Maybe enable/disable filtering with a setting?
+            // if ((applicationInfo.flags & ApplicationInfo.FLAG_SYSTEM) == 0) {
+            //     names.add(applicationInfo.packageName);
+            // }
+            names.add(applicationInfo.packageName);
         }
         return names.toArray(new String[0]);
     }

--- a/app/src/main/java/ch/bfh/adaid/settings/A11yTileService.java
+++ b/app/src/main/java/ch/bfh/adaid/settings/A11yTileService.java
@@ -1,0 +1,82 @@
+package ch.bfh.adaid.settings;
+
+import android.content.Intent;
+import android.service.quicksettings.Tile;
+import android.service.quicksettings.TileService;
+import android.util.Log;
+
+import ch.bfh.adaid.service.A11yService;
+
+public class A11yTileService extends TileService {
+    private static final String TAG = "A11yTileService";
+
+    /**
+     * Called when the system adds the tile for the first time.
+     */
+    @Override
+    public void onTileAdded() {
+        super.onTileAdded();
+        Tile tile = getQsTile();
+        boolean a11yEnabled = A11yService.isServiceEnabled(this);
+        tile.setState(a11yEnabled ? Tile.STATE_ACTIVE : Tile.STATE_UNAVAILABLE);
+        tile.updateTile();
+    }
+
+    /**
+     * Called when the systems want to check the sate of the quick tile.
+     */
+    @Override
+    public void onStartListening() {
+        super.onStartListening();
+        Tile tile = getQsTile();
+        boolean a11yEnabled = A11yService.isServiceEnabled(this);
+        int state = tile.getState();
+        if (!a11yEnabled) {
+            tile.setState(Tile.STATE_UNAVAILABLE);
+        } else if (state == Tile.STATE_UNAVAILABLE) {
+            tile.setState(Tile.STATE_ACTIVE);
+            sendOnOff(true);
+        }
+        tile.updateTile();
+    }
+
+    /**
+     * Called when user clicks on the tile.
+     */
+    @Override
+    public void onClick() {
+        super.onClick();
+        // Toggle the state.
+        Tile tile = getQsTile();
+        int state = tile.getState();
+        if (state == Tile.STATE_ACTIVE) {
+            tile.setState(Tile.STATE_INACTIVE);
+            sendOnOff(false);
+        } else if (state == Tile.STATE_INACTIVE) {
+            tile.setState(Tile.STATE_ACTIVE);
+            sendOnOff(true);
+        }
+        tile.updateTile();
+    }
+
+    /**
+     * Called when user removes the tile.
+     */
+    @Override
+    public void onTileRemoved() {
+        super.onTileRemoved();
+        // If Tile is removed, ensure that the service is enabled.
+        sendOnOff(true);
+    }
+
+    /**
+     * Send an on or off command to the a11y service.
+     *
+     * @param on True if the service should be turned on, false otherwise.
+     */
+    private void sendOnOff(boolean on) {
+        Log.d(TAG, "sending " + (on ? "on" : "off") + " command to a11y service");
+        Intent intent = A11yService.getQuickTileOnOffIntent(this, on);
+        startService(intent);
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -17,8 +17,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
-        android:layout_marginEnd="@dimen/fab_margin"
-        android:layout_marginBottom="@dimen/fab_margin"
+        android:layout_marginEnd="@dimen/double_margin"
+        android:layout_marginBottom="@dimen/double_margin"
         app:srcCompat="@android:drawable/ic_input_add" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,6 +7,18 @@
     android:layout_height="match_parent"
     tools:context=".gui.main.MainActivity">
 
+    <TextView
+        android:id="@+id/empty_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="@string/rule_empty_view_text"
+        android:gravity="center"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="parent"
+        tools:visibility="gone" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,7 +10,10 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:paddingBottom="@dimen/fab_offset_height"
+        tools:listitem="@layout/recyclerview_row" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab"
@@ -19,6 +22,7 @@
         android:layout_gravity="bottom|end"
         android:layout_marginEnd="@dimen/double_margin"
         android:layout_marginBottom="@dimen/double_margin"
+        android:contentDescription="@string/rule_fab_description"
         app:srcCompat="@android:drawable/ic_input_add" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_rule.xml
+++ b/app/src/main/res/layout/activity_rule.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout xmlns:tools="http://schemas.android.com/tools"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
@@ -44,6 +45,7 @@
                 android:id="@+id/dropdownApp"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:importantForAutofill="no"
                 tools:ignore="TextContrastCheck" />
 
         </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout/recyclerview_row.xml
+++ b/app/src/main/res/layout/recyclerview_row.xml
@@ -1,33 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/normal_margin"
+    android:layout_marginTop="@dimen/normal_margin"
+    android:layout_marginEnd="@dimen/normal_margin"
     android:clickable="true"
-    android:focusable="true"
-    android:foreground="?android:attr/selectableItemBackground"
-    android:padding="30dp">
+    app:cardCornerRadius="@dimen/card_corner_radius">
 
-    <TextView
-        android:id="@+id/ruleName"
-        android:layout_width="wrap_content"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textSize="20sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/ruleSwitch"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:padding="30dp">
 
-    <com.google.android.material.switchmaterial.SwitchMaterial
-        android:id="@+id/ruleSwitch"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text=""
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="1.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        <TextView
+            android:id="@+id/ruleName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="20sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/ruleSwitch"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Sample Rule Name" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <com.google.android.material.switchmaterial.SwitchMaterial
+            android:id="@+id/ruleSwitch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -32,6 +32,7 @@
     <string name="rule_action_type_note">Aktionen die ausgelöst werden können: Nach (links/rechts/oben/unten) wischen - Führt eine Wischgeste über den gesamten Bildschirm aus, Klicken - Klickt auf das View, Stummschalten - Schalte die Musikausgabe so lange auf stumm wie das View sichtbar ist, Blockieren - Überblendet das View mit einer schwarzen Box, Zurückgehen - Navigiere zurück.</string>
     <string name="rule_helper_row_id_label">Id</string>
     <string name="rule_fab_description">Eine Regel hinzufügen</string>
+    <string name="rule_empty_view_text">Leer … noch keine Regeln konfiguriert.</string>
     <string name="rule_helper_activity_title">Regelhelfer</string>
     <string name="rule_helper_row_text_label">Text</string>
     <string name="rule_view_id_note">Die Id der View welche diese Regel auslösen soll. Dies ist nicht trivial zu finden. Benutze den Regelhelfer (? Symbol, oben rechts) um sie zu finden.</string>
@@ -52,4 +53,5 @@
     <string name="rule_helper_cancel_message">Falsche Nutzungssequenz, Regelhelfer Mechanismus wurde abgebrochen. Bitte wiederholen.</string>
     <string name="rule_relative_path_note">Optionaler relativer Pfad zu einem view auf dessen die Aktion ausgeführt werden soll. Kodiert wie folgt: p - ein Parent hoch, c[n] - zum nten Child (0 indexiert), sd - ein Sibling runter, su - ein Sibling hoch. Diese könnten, getrennt von einem Punkt verkettet werden z.B.: p.p.su.c[2]. Leer lassen um auf dem auslösenden View selbst zu agieren.</string>
     <string name="rule_relative_path">Relativer Pfad</string>
+    <string name="no_rules_configured">No rules configured.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -14,6 +14,7 @@
     <string name="action_click">Klicken</string>
     <string name="action_mute">Stummschalten</string>
     <string name="action_back">Zurückgehen</string>
+    <string name="action_block">Blockieren</string>
     <string name="rule_name">Namen</string>
     <string name="rule_name_error">Bitte einen Namen eingeben</string>
     <string name="rule_enabled">Aktiviert</string>
@@ -41,13 +42,13 @@
     <string name="rule_helper_dialog_negative">Abbrechen</string>
     <string name="rule_helper_dialog_neutral">Vorherige Aufnahme verwenden</string>
     <string name="rule_helper_dialog_service_not_enabled">Bitte zuerst den Bedienungshilfendienst dieser App aktivieren.</string>
+    <string name="rule_helper_notification_permission_deny_message">Erlaubnis Benachrichtigungen zu zeigen wurde abgelehnt. Regelhelfer wird beendet.</string>
     <string name="rule_helper_notification_channel_name">Allgemein</string>
     <string name="rule_helper_notification_title">Regelhelfer</string>
     <string name="rule_helper_notification_text" tools:ignore="Typos">Klicke auf diese Benachrichtigung wenn die View, für die die Werte gefunden werden sollten, sichtbar ist.</string>
+    <string name="rule_helper_reuse_error_message">Konnte die vorherige Aufnahme nicht verwenden. Bitte wiederholen.</string>
     <string name="rule_helper_value_not_set">-- ohne Id --</string>
     <string name="rule_helper_cancel_message">Falsche Nutzungssequenz, Regelhelfer Mechanismus wurde abgebrochen. Bitte wiederholen.</string>
-    <string name="action_block">Blockieren</string>
     <string name="rule_relative_path_note">Optionaler relativer Pfad zu einem view auf dessen die Aktion ausgeführt werden soll. Kodiert wie folgt: p - ein Parent hoch, c[n] - zum nten Child (0 indexiert), sd - ein Sibling runter, su - ein Sibling hoch. Diese könnten, getrennt von einem Punkt verkettet werden z.B.: p.p.su.c[2]. Leer lassen um auf dem auslösenden View selbst zu agieren.</string>
     <string name="rule_relative_path">Relativer Pfad</string>
-    <string name="rule_helper_reuse_error_message">Konnte die vorherige Aufnahme nicht verwenden. Bitte wiederholen.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -31,6 +31,7 @@
     <string name="rule_db_error">Datenbankfehler %s. Bitte erneut versuchen.</string>
     <string name="rule_action_type_note">Aktionen die ausgelöst werden können: Nach (links/rechts/oben/unten) wischen - Führt eine Wischgeste über den gesamten Bildschirm aus, Klicken - Klickt auf das View, Stummschalten - Schalte die Musikausgabe so lange auf stumm wie das View sichtbar ist, Blockieren - Überblendet das View mit einer schwarzen Box, Zurückgehen - Navigiere zurück.</string>
     <string name="rule_helper_row_id_label">Id</string>
+    <string name="rule_fab_description">Eine Regel hinzufügen</string>
     <string name="rule_helper_activity_title">Regelhelfer</string>
     <string name="rule_helper_row_text_label">Text</string>
     <string name="rule_view_id_note">Die Id der View welche diese Regel auslösen soll. Dies ist nicht trivial zu finden. Benutze den Regelhelfer (? Symbol, oben rechts) um sie zu finden.</string>

--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -1,3 +1,0 @@
-<resources>
-    <dimen name="fab_margin">48dp</dimen>
-</resources>

--- a/app/src/main/res/values-w1240dp/dimens.xml
+++ b/app/src/main/res/values-w1240dp/dimens.xml
@@ -1,3 +1,0 @@
-<resources>
-    <dimen name="fab_margin">200dp</dimen>
-</resources>

--- a/app/src/main/res/values-w600dp/dimens.xml
+++ b/app/src/main/res/values-w600dp/dimens.xml
@@ -1,3 +1,0 @@
-<resources>
-    <dimen name="fab_margin">48dp</dimen>
-</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,4 +3,6 @@
     <!-- 2x normal_margin -->
     <dimen name="double_margin">16dp</dimen>
     <dimen name="card_corner_radius">16dp</dimen>
+    <!-- 2x double_margin + 56dp (default FAB size) -->
+    <dimen name="fab_offset_height">88dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,3 +1,6 @@
 <resources>
-    <dimen name="fab_margin">16dp</dimen>
+    <dimen name="normal_margin">8dp</dimen>
+    <!-- 2x normal_margin -->
+    <dimen name="double_margin">16dp</dimen>
+    <dimen name="card_corner_radius">16dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="rule_db_error">Database error %s. Please try again.</string>
     <string name="rule_action_bar_help">Help finding values</string>
     <string name="rule_fab_description">Add a rule</string>
+    <string name="rule_empty_view_text">Empty … no rules configured so far.</string>
 
     <!-- Strings for rule helper activity -->
     <string name="rule_helper_activity_title">Rule helper</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="rule_button_delete">Delete rule</string>
     <string name="rule_db_error">Database error %s. Please try again.</string>
     <string name="rule_action_bar_help">Help finding values</string>
+    <string name="rule_fab_description">Add a rule</string>
 
     <!-- Strings for rule helper activity -->
     <string name="rule_helper_activity_title">Rule helper</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,7 @@
     <string name="rule_helper_dialog_service_not_enabled">Please enable the accessibility service of this app first.</string>
 
     <!-- Strings used for rule helper notification -->
+    <string name="rule_helper_notification_permission_deny_message">Permission for notifications have been denied. Aborting the helper.</string>
     <string name="rule_helper_notification_channel_name">General</string>
     <string name="rule_helper_notification_title">Helping you find the rule values</string>
     <string name="rule_helper_notification_text">When the view you want to find the values for is visible, tap this notification to take a snapshot and return to the rule creation.</string>


### PR DESCRIPTION
- Disable autofill for app package name in rule editor. Autofill would never contain the package names and only prevent the dropdown from showing.
- On my phone (OnePlus 8) the filtering for non-system apps added in #1 prevented youtube (`com.google.android.youtube`) to show up as app.
- Notifications were permanently disabled with the build now targeting a more recent version of the SDK. Previously the notifications could simply be enabled manually. This is no longer possible and instead we are required to explicitly request the permission.
- Make list of configured rules more distinct with a Card View.
- Allow overscroll of recycler list to scroll item up above FAB.
- Show informal text when the rule list is empty.
- Add quick tile setting #46 